### PR TITLE
Loosen activesupport dependency

### DIFF
--- a/baremetrics_api.gemspec
+++ b/baremetrics_api.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday',  '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.11'
   spec.add_dependency 'httpclient', '~> 2.8'
-  spec.add_dependency 'activesupport', '~> 5.0'
+  spec.add_dependency 'activesupport', '4.0.13'
 end


### PR DESCRIPTION
As it seems like the gem works fine with looser active support dependency, we might as well make it less strict in requirements. 