### PR TITLE
Loosen activesupport requirements

### DIFF
--- a/baremetrics_api.gemspec
+++ b/baremetrics_api.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday',  '~> 0.9'
   spec.add_dependency 'faraday_middleware', '~> 0.11'
   spec.add_dependency 'httpclient', '~> 2.8'
-  spec.add_dependency 'activesupport', '4.0.13'
+  spec.add_dependency 'activesupport', '>= 4.0.13'
 end


### PR DESCRIPTION
We want to ensure that a minimum of 4.0.13 version of activesupport is supported, but not just that version.